### PR TITLE
Fixed a bug where dependency materials were not importing name correctly

### DIFF
--- a/gocd/import_gocd_pipeline_test.go
+++ b/gocd/import_gocd_pipeline_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func testResourcePipelineImportBasic(t *testing.T) {
-	for _, idx := range []int{4} { //{2,4}
+	for _, idx := range []int{2, 4, 5} { //{2,4}
 		suffix := randomString(10)
 		resourceName := fmt.Sprintf("gocd_pipeline.test-%s", suffix)
 

--- a/gocd/resource_pipeline.go
+++ b/gocd/resource_pipeline.go
@@ -179,6 +179,7 @@ func resourcePipelineRead(d *schema.ResourceData, meta interface{}) error {
 	if pname, hasName := d.GetOk("name"); hasName {
 		name = pname.(string)
 		d.SetId(name)
+		d.Set("name", name)
 	}
 	client := meta.(*gocd.Client)
 	client.Lock()
@@ -199,6 +200,8 @@ func resourcePipelineUpdate(d *schema.ResourceData, meta interface{}) error {
 	var name string
 	if pname, hasName := d.GetOk("name"); hasName {
 		name = pname.(string)
+		d.SetId(name)
+		d.Set("name", name)
 	}
 
 	templateToPipeline, templateChange := isSwitchToTemplate(d)

--- a/gocd/resource_pipeline.go
+++ b/gocd/resource_pipeline.go
@@ -3,6 +3,7 @@ package gocd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/drewsonne/go-gocd/gocd"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -155,8 +156,9 @@ func resourcePipeline() *schema.Resource {
 	}
 }
 
-func resourcePipelineCreate(d *schema.ResourceData, meta interface{}) error {
+func resourcePipelineCreate(d *schema.ResourceData, meta interface{}) (err error) {
 	var group string
+	var p *gocd.Pipeline
 	if ptgroup, hasGroup := d.GetOk("group"); hasGroup {
 		group = ptgroup.(string)
 	}
@@ -164,7 +166,9 @@ func resourcePipelineCreate(d *schema.ResourceData, meta interface{}) error {
 	client.Lock()
 	defer client.Unlock()
 
-	p := extractPipeline(d)
+	if p, err = extractPipeline(d); err != nil {
+		return err
+	}
 	if (p.Stages == nil || len(p.Stages) == 0) && p.Template == "" {
 		p.Stages = []*gocd.Stage{
 			stagePlaceHolder(),
@@ -196,8 +200,9 @@ func resourcePipelineRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourcePipelineUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourcePipelineUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 	var name string
+	var p *gocd.Pipeline
 	if pname, hasName := d.GetOk("name"); hasName {
 		name = pname.(string)
 		d.SetId(name)
@@ -206,7 +211,9 @@ func resourcePipelineUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	templateToPipeline, templateChange := isSwitchToTemplate(d)
 
-	p := extractPipeline(d)
+	if p, err = extractPipeline(d); err != nil {
+		return err
+	}
 
 	if templateChange && !templateToPipeline {
 		p.Stages = nil
@@ -263,8 +270,8 @@ func resourcePipelineStateImport() *schema.ResourceImporter {
 	}
 }
 
-func extractPipeline(d *schema.ResourceData) *gocd.Pipeline {
-	p := gocd.Pipeline{}
+func extractPipeline(d *schema.ResourceData) (p *gocd.Pipeline, err error) {
+	p = &gocd.Pipeline{}
 
 	if template, hasTemplate := d.GetOk("template"); hasTemplate {
 		p.Template = template.(string)
@@ -274,7 +281,9 @@ func extractPipeline(d *schema.ResourceData) *gocd.Pipeline {
 
 	rawMaterials := d.Get("materials")
 	if materials := rawMaterials.([]interface{}); len(materials) > 0 {
-		p.Materials = extractPipelineMaterials(materials)
+		if p.Materials, err = extractPipelineMaterials(materials); err != nil {
+			return nil, err
+		}
 	}
 
 	rawParameters := d.Get("parameters")
@@ -282,7 +291,7 @@ func extractPipeline(d *schema.ResourceData) *gocd.Pipeline {
 		p.Parameters = extractPipelineParameters(parameters)
 	}
 
-	return &p
+	return p, nil
 }
 
 func extractPipelineParameters(rawProperties map[string]interface{}) []*gocd.Parameter {
@@ -296,7 +305,7 @@ func extractPipelineParameters(rawProperties map[string]interface{}) []*gocd.Par
 	return ps
 }
 
-func extractPipelineMaterials(rawMaterials []interface{}) []gocd.Material {
+func extractPipelineMaterials(rawMaterials []interface{}) ([]gocd.Material, error) {
 	ms := []gocd.Material{}
 	for _, rawMaterial := range rawMaterials {
 		mat := rawMaterial.(map[string]interface{})
@@ -312,27 +321,34 @@ func extractPipelineMaterials(rawMaterials []interface{}) []gocd.Material {
 
 			rawAttr := mAttributes.([]interface{})[0].(map[string]interface{})
 			for attrKey, attrValue := range rawAttr {
+				if s, ok := attrValue.(string); ok && s == "" {
+					continue
+				}
 				switch attrKey {
-				case "name":
-					attr.Name = attrValue.(string)
 				case "url":
 					attr.URL = attrValue.(string)
-				case "branch":
-					attr.Branch = attrValue.(string)
 				case "destination":
 					attr.Destination = attrValue.(string)
-				case "auto_update":
-					attr.AutoUpdate = attrValue.(bool)
 				case "filter":
 					attr.Filter = extractPipelineMaterialFilter(attrValue)
 				case "invert_filter":
 					attr.InvertFilter = attrValue.(bool)
-				case "stage":
-					attr.Stage = attrValue.(string)
+				case "name":
+					attr.Name = attrValue.(string)
+				case "auto_update":
+					attr.AutoUpdate = attrValue.(bool)
+				case "branch":
+					attr.Branch = attrValue.(string)
 				case "submodule_folder":
 					attr.SubmoduleFolder = attrValue.(string)
 				case "shallow_clone":
 					attr.ShallowClone = attrValue.(bool)
+				case "pipeline":
+					attr.Pipeline = attrValue.(string)
+				case "stage":
+					attr.Stage = attrValue.(string)
+				default:
+					return nil, fmt.Errorf("Unexpected material attribute: `%s:%s`", attrKey, attrValue)
 				}
 			}
 
@@ -341,7 +357,7 @@ func extractPipelineMaterials(rawMaterials []interface{}) []gocd.Material {
 		ms = append(ms, m)
 
 	}
-	return ms
+	return ms, nil
 }
 
 func readPipelineMaterials(d *schema.ResourceData, materials []gocd.Material) error {
@@ -355,8 +371,17 @@ func readPipelineMaterials(d *schema.ResourceData, materials []gocd.Material) er
 			"auto_update":   m.Attributes.AutoUpdate,
 			"branch":        m.Attributes.Branch,
 			"destination":   m.Attributes.Destination,
-			"name":          m.Attributes.Name,
 			"invert_filter": m.Attributes.InvertFilter,
+			"stage":         m.Attributes.Stage,
+			"pipeline":      m.Attributes.Pipeline,
+		}
+
+		if m.Type == "dependency" {
+			if m.Attributes.Name != m.Attributes.Pipeline {
+				attrs["name"] = m.Attributes.Name
+			}
+		} else {
+			attrs["name"] = m.Attributes.Name
 		}
 
 		filter := make([]map[string]interface{}, 1)

--- a/gocd/test/resource_pipeline.5.rsc.tf
+++ b/gocd/test/resource_pipeline.5.rsc.tf
@@ -7,7 +7,7 @@ resource "gocd_pipeline_template" "gocd-image-build-deploy" {
 # CMD terraform import gocd_pipeline_stage.build "build"
 resource "gocd_pipeline_stage" "build" {
   name = "build"
-  pipeline_template = "gocd-image-build-deploy"
+  pipeline_template = "${gocd_pipeline_template.gocd-image-build-deploy.name}"
   fetch_materials = true
   jobs = [
     "${data.gocd_job_definition.build.json}"
@@ -33,7 +33,7 @@ data "gocd_task_definition" "gocd-image-build-deploy_build_build_0" {
 # CMD terraform import gocd_pipeline_stage.clean "clean"
 resource "gocd_pipeline_stage" "clean" {
   name = "clean"
-  pipeline_template = "gocd-image-build-deploy"
+  pipeline_template = "${gocd_pipeline_template.gocd-image-build-deploy.name}"
   fetch_materials = true
   jobs = [
     "${data.gocd_job_definition.clean.json}"
@@ -61,7 +61,7 @@ data "gocd_task_definition" "gocd-image-build-deploy_clean_clean_0" {
 # CMD terraform import gocd_pipeline_stage.deploy "deploy"
 resource "gocd_pipeline_stage" "deploy" {
   name = "deploy"
-  pipeline_template = "gocd-image-build-deploy"
+  pipeline_template = "${gocd_pipeline_template.gocd-image-build-deploy.name}"
   fetch_materials = true
   jobs = [
     "${data.gocd_job_definition.deploy.json}"
@@ -104,8 +104,7 @@ resource "gocd_pipeline" "terraform-image" {
     {
       type = "dependency"
       attributes {
-//        name = "terraform-image"
-        pipeline = "${gocd_pipeline.base-image.id}"
+        pipeline = "${gocd_pipeline.base-image.name}"
         stage = "clean"
         auto_update = true
       }
@@ -115,11 +114,10 @@ resource "gocd_pipeline" "terraform-image" {
 resource "gocd_pipeline" "base-image" {
   name = "base-image"
   group = "ecsagent"
-  template = "gocd-image-build-deploy"
+  template = "${gocd_pipeline_template.gocd-image-build-deploy.name}"
   parameters {
     Image = "base",
   }
-
   materials = [
     {
       type = "git"

--- a/gocd/test/resource_pipeline.5.rsc.tf
+++ b/gocd/test/resource_pipeline.5.rsc.tf
@@ -104,14 +104,15 @@ resource "gocd_pipeline" "terraform-image" {
     {
       type = "dependency"
       attributes {
-        pipeline = "${gocd_pipeline.base-image.name}"
-        stage = "clean"
+        pipeline = "${gocd_pipeline.test-pipeline.name}"
+        stage = "${gocd_pipeline_stage.clean.name}"
         auto_update = true
       }
     },
   ]
 }
-resource "gocd_pipeline" "base-image" {
+
+resource "gocd_pipeline" "test-pipeline" {
   name = "base-image"
   group = "ecsagent"
   template = "${gocd_pipeline_template.gocd-image-build-deploy.name}"

--- a/gocd/test/resource_pipeline.5.rsc.tf
+++ b/gocd/test/resource_pipeline.5.rsc.tf
@@ -1,0 +1,140 @@
+## START pipeline_template.gocd-image-build-deploy
+# CMD terraform import gocd_pipeline_template.gocd-image-build-deploy "gocd-image-build-deploy"
+resource "gocd_pipeline_template" "gocd-image-build-deploy" {
+  name = "gocd-image-build-deploy"
+}
+
+# CMD terraform import gocd_pipeline_stage.build "build"
+resource "gocd_pipeline_stage" "build" {
+  name = "build"
+  pipeline_template = "gocd-image-build-deploy"
+  fetch_materials = true
+  jobs = [
+    "${data.gocd_job_definition.build.json}"
+  ]
+}
+data "gocd_job_definition" "build" {
+  name = "build"
+  tasks = [
+    "${data.gocd_task_definition.gocd-image-build-deploy_build_build_0.json}",
+  ]
+  resources = [
+    "v5.80"]
+}
+data "gocd_task_definition" "gocd-image-build-deploy_build_build_0" {
+  type = "exec"
+  run_if = [
+    "passed"]
+  command = "make"
+  arguments = [
+    "build"]
+}
+
+# CMD terraform import gocd_pipeline_stage.clean "clean"
+resource "gocd_pipeline_stage" "clean" {
+  name = "clean"
+  pipeline_template = "gocd-image-build-deploy"
+  fetch_materials = true
+  jobs = [
+    "${data.gocd_job_definition.clean.json}"
+  ]
+}
+data "gocd_job_definition" "clean" {
+  name = "clean"
+  tasks = [
+    "${data.gocd_task_definition.gocd-image-build-deploy_clean_clean_0.json}",
+  ]
+  resources = [
+    "v5.80"]
+}
+data "gocd_task_definition" "gocd-image-build-deploy_clean_clean_0" {
+  type = "exec"
+  run_if = [
+    "passed"]
+  command = "docker"
+  arguments = [
+    "system",
+    "prune",
+    "-f"]
+}
+
+# CMD terraform import gocd_pipeline_stage.deploy "deploy"
+resource "gocd_pipeline_stage" "deploy" {
+  name = "deploy"
+  pipeline_template = "gocd-image-build-deploy"
+  fetch_materials = true
+  jobs = [
+    "${data.gocd_job_definition.deploy.json}"
+  ]
+}
+data "gocd_job_definition" "deploy" {
+  name = "deploy"
+  tasks = [
+    "${data.gocd_task_definition.gocd-image-build-deploy_deploy_deploy_0.json}",
+  ]
+  resources = [
+    "v5.80"]
+}
+data "gocd_task_definition" "gocd-image-build-deploy_deploy_deploy_0" {
+  type = "exec"
+  run_if = [
+    "passed"]
+  command = "make"
+  arguments = [
+    "deploy"]
+}
+
+## END
+resource "gocd_pipeline" "terraform-image" {
+  name = "terraform-image"
+  group = "ecsagent"
+  template = "${gocd_pipeline_template.gocd-image-build-deploy.name}"
+  parameters {
+    Image = "terraform",
+  }
+  materials = [
+    {
+      type = "git"
+      attributes {
+        url = "git@github.com:company/gocd-ecsagents.git"
+        branch = "master"
+        auto_update = true
+      }
+    },
+    {
+      type = "dependency"
+      attributes {
+//        name = "terraform-image"
+        pipeline = "${gocd_pipeline.base-image.id}"
+        stage = "clean"
+        auto_update = true
+      }
+    },
+  ]
+}
+resource "gocd_pipeline" "base-image" {
+  name = "base-image"
+  group = "ecsagent"
+  template = "gocd-image-build-deploy"
+  parameters {
+    Image = "base",
+  }
+
+  materials = [
+    {
+      type = "git"
+      attributes {
+        url = "git@github.com:company/gocd-ecsagents.git"
+        filter = {
+          ignore = [
+            "company-gocd-agents/Dockerfile.base",
+            "Makefile",
+            "company-gocd-agents/files/base/"]
+        }
+        invert_filter = true
+        branch = "master"
+        auto_update = true
+      }
+    },
+  ]
+}


### PR DESCRIPTION
If the `name` attribute is left blank when creating a dependency material, when the material is queried, then `name` attribute is filled in with the `pipeline` value.